### PR TITLE
Prevent block picking from showing up a screen other than ChatScreen is open.

### DIFF
--- a/src/client/java/fish/crafting/fimfabric/util/CursorPicking.java
+++ b/src/client/java/fish/crafting/fimfabric/util/CursorPicking.java
@@ -80,7 +80,6 @@ public class CursorPicking {
 
     public static boolean areBlockPickingPrerequisitesMet(){
         MinecraftClient client = MinecraftClient.getInstance();
-        System.out.println(client.currentScreen);
         return KeyUtil.isControlPressed() &&
                 !client.mouse.isCursorLocked() &&
                 client.currentScreen instanceof ChatScreen;

--- a/src/client/java/fish/crafting/fimfabric/util/CursorPicking.java
+++ b/src/client/java/fish/crafting/fimfabric/util/CursorPicking.java
@@ -5,7 +5,6 @@ import fish.crafting.fimfabric.util.cache.RenderFrameCache;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ChatScreen;
-import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.render.Camera;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;

--- a/src/client/java/fish/crafting/fimfabric/util/CursorPicking.java
+++ b/src/client/java/fish/crafting/fimfabric/util/CursorPicking.java
@@ -4,7 +4,8 @@ import fish.crafting.fimfabric.rendering.custom.RenderContext3D;
 import fish.crafting.fimfabric.util.cache.RenderFrameCache;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.gui.screen.ChatScreen;
+import net.minecraft.client.gui.screen.GameMenuScreen;
 import net.minecraft.client.render.Camera;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
@@ -80,7 +81,10 @@ public class CursorPicking {
 
     public static boolean areBlockPickingPrerequisitesMet(){
         MinecraftClient client = MinecraftClient.getInstance();
-        return KeyUtil.isControlPressed() && !client.mouse.isCursorLocked() && !(client.currentScreen instanceof InventoryScreen);
+        System.out.println(client.currentScreen);
+        return KeyUtil.isControlPressed() &&
+                !client.mouse.isCursorLocked() &&
+                client.currentScreen instanceof ChatScreen;
     }
 
     public static BlockHitResult raycast(){

--- a/src/client/java/fish/crafting/fimfabric/util/CursorPicking.java
+++ b/src/client/java/fish/crafting/fimfabric/util/CursorPicking.java
@@ -4,6 +4,7 @@ import fish.crafting.fimfabric.rendering.custom.RenderContext3D;
 import fish.crafting.fimfabric.util.cache.RenderFrameCache;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.render.Camera;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
@@ -78,7 +79,8 @@ public class CursorPicking {
     }
 
     public static boolean areBlockPickingPrerequisitesMet(){
-        return KeyUtil.isControlPressed() && !MinecraftClient.getInstance().mouse.isCursorLocked();
+        MinecraftClient client = MinecraftClient.getInstance();
+        return KeyUtil.isControlPressed() && !client.mouse.isCursorLocked() && !(client.currentScreen instanceof InventoryScreen);
     }
 
     public static BlockHitResult raycast(){


### PR DESCRIPTION
Edited the boolean areBlockPickingPrerequisitesMet() from CursorPicking.java so it prevents the block selection UI from on screens other than the ChatScreen.